### PR TITLE
[feat] 매입 이력 추가 서비스 구현

### DIFF
--- a/fineAnts_app/src/main/java/codesquad/fineants/domain/purchase_history/PurchaseHistory.java
+++ b/fineAnts_app/src/main/java/codesquad/fineants/domain/purchase_history/PurchaseHistory.java
@@ -14,8 +14,10 @@ import codesquad.fineants.domain.BaseEntity;
 import codesquad.fineants.domain.portfolio_holding.PortfolioHolding;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PurchaseHistory extends BaseEntity {

--- a/fineAnts_app/src/main/java/codesquad/fineants/domain/purchase_history/PurchaseHistory.java
+++ b/fineAnts_app/src/main/java/codesquad/fineants/domain/purchase_history/PurchaseHistory.java
@@ -16,8 +16,10 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
+@ToString(exclude = {"portFolioHolding"})
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PurchaseHistory extends BaseEntity {

--- a/fineAnts_app/src/main/java/codesquad/fineants/spring/api/errors/errorcode/PortfolioHoldingErrorCode.java
+++ b/fineAnts_app/src/main/java/codesquad/fineants/spring/api/errors/errorcode/PortfolioHoldingErrorCode.java
@@ -1,0 +1,25 @@
+package codesquad.fineants.spring.api.errors.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PortfolioHoldingErrorCode implements ErrorCode {
+
+	NOT_FOUND_PORTFOLIO_HOLDING(HttpStatus.NOT_FOUND, "포트폴리오 종목이 존재하지 않습니다");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "포트폴리오 에러 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/fineAnts_app/src/main/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioStockService.java
+++ b/fineAnts_app/src/main/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioStockService.java
@@ -18,7 +18,7 @@ import codesquad.fineants.domain.purchase_history.PurchaseHistoryRepository;
 import codesquad.fineants.domain.stock.Stock;
 import codesquad.fineants.domain.stock.StockRepository;
 import codesquad.fineants.spring.api.errors.errorcode.PortfolioErrorCode;
-import codesquad.fineants.spring.api.errors.errorcode.PortfolioStockErrorCode;
+import codesquad.fineants.spring.api.errors.errorcode.PortfolioHoldingErrorCode;
 import codesquad.fineants.spring.api.errors.errorcode.StockErrorCode;
 import codesquad.fineants.spring.api.errors.exception.ForBiddenException;
 import codesquad.fineants.spring.api.errors.exception.NotFoundResourceException;
@@ -79,7 +79,7 @@ public class PortfolioStockService {
 		try {
 			portFolioHoldingRepository.deleteById(portfolioHoldingId);
 		} catch (EmptyResultDataAccessException e) {
-			throw new NotFoundResourceException(PortfolioStockErrorCode.NOT_FOUND_PORTFOLIO_STOCK);
+			throw new NotFoundResourceException(PortfolioHoldingErrorCode.NOT_FOUND_PORTFOLIO_HOLDING);
 		}
 		return new PortfolioStockDeleteResponse(portfolioHoldingId);
 	}

--- a/fineAnts_app/src/main/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryRestController.java
+++ b/fineAnts_app/src/main/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryRestController.java
@@ -1,0 +1,32 @@
+package codesquad.fineants.spring.api.purchase_history;
+
+import javax.validation.Valid;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import codesquad.fineants.domain.oauth.support.AuthMember;
+import codesquad.fineants.domain.oauth.support.AuthPrincipalMember;
+import codesquad.fineants.spring.api.purchase_history.request.PurchaseHistoryCreateRequest;
+import codesquad.fineants.spring.api.response.ApiResponse;
+import codesquad.fineants.spring.api.success.code.PurchaseHistorySuccessCode;
+import lombok.RequiredArgsConstructor;
+
+@RequestMapping("/api/portfolio/{portfolioId}/holdings/{portfolioHoldingId}/purchaseHistory")
+@RequiredArgsConstructor
+@RestController
+public class PurchaseHistoryRestController {
+
+	private final PurchaseHistoryService service;
+
+	@PostMapping
+	public ApiResponse<Void> addPurchaseHistory(@Valid @RequestBody PurchaseHistoryCreateRequest request,
+		@PathVariable Long portfolioHoldingId,
+		@AuthPrincipalMember AuthMember authMember) {
+		service.addPurchaseHistory(request, portfolioHoldingId, authMember);
+		return ApiResponse.success(PurchaseHistorySuccessCode.CREATED_ADD_PURCHASE_HISTORY);
+	}
+}

--- a/fineAnts_app/src/main/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryRestController.java
+++ b/fineAnts_app/src/main/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryRestController.java
@@ -2,10 +2,12 @@ package codesquad.fineants.spring.api.purchase_history;
 
 import javax.validation.Valid;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import codesquad.fineants.domain.oauth.support.AuthMember;
@@ -14,7 +16,9 @@ import codesquad.fineants.spring.api.purchase_history.request.PurchaseHistoryCre
 import codesquad.fineants.spring.api.response.ApiResponse;
 import codesquad.fineants.spring.api.success.code.PurchaseHistorySuccessCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequestMapping("/api/portfolio/{portfolioId}/holdings/{portfolioHoldingId}/purchaseHistory")
 @RequiredArgsConstructor
 @RestController
@@ -22,10 +26,12 @@ public class PurchaseHistoryRestController {
 
 	private final PurchaseHistoryService service;
 
+	@ResponseStatus(HttpStatus.CREATED)
 	@PostMapping
 	public ApiResponse<Void> addPurchaseHistory(@Valid @RequestBody PurchaseHistoryCreateRequest request,
 		@PathVariable Long portfolioHoldingId,
 		@AuthPrincipalMember AuthMember authMember) {
+		log.info("매입 내역 추가 요청 : request={}, portfolioHoldingId={}", request, portfolioHoldingId);
 		service.addPurchaseHistory(request, portfolioHoldingId, authMember);
 		return ApiResponse.success(PurchaseHistorySuccessCode.CREATED_ADD_PURCHASE_HISTORY);
 	}

--- a/fineAnts_app/src/main/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryService.java
+++ b/fineAnts_app/src/main/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryService.java
@@ -34,6 +34,7 @@ public class PurchaseHistoryService {
 		PortfolioHolding portfolioHolding = findPortfolioHolding(portfolioHoldingId);
 		validatePortfolioAuthorization(portfolioHolding.getPortfolio(), authMember.getMemberId());
 		PurchaseHistory savePurchaseHistory = repository.save(request.toEntity(portfolioHolding));
+		log.info("매입이력 저장 결과 : {}", savePurchaseHistory);
 		return PurchaseHistoryCreateResponse.from(savePurchaseHistory);
 	}
 

--- a/fineAnts_app/src/main/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryService.java
+++ b/fineAnts_app/src/main/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryService.java
@@ -1,0 +1,50 @@
+package codesquad.fineants.spring.api.purchase_history;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import codesquad.fineants.domain.oauth.support.AuthMember;
+import codesquad.fineants.domain.portfolio.Portfolio;
+import codesquad.fineants.domain.portfolio_holding.PortFolioHoldingRepository;
+import codesquad.fineants.domain.portfolio_holding.PortfolioHolding;
+import codesquad.fineants.domain.purchase_history.PurchaseHistory;
+import codesquad.fineants.domain.purchase_history.PurchaseHistoryRepository;
+import codesquad.fineants.spring.api.errors.errorcode.PortfolioErrorCode;
+import codesquad.fineants.spring.api.errors.errorcode.PortfolioHoldingErrorCode;
+import codesquad.fineants.spring.api.errors.exception.ForBiddenException;
+import codesquad.fineants.spring.api.errors.exception.NotFoundResourceException;
+import codesquad.fineants.spring.api.purchase_history.request.PurchaseHistoryCreateRequest;
+import codesquad.fineants.spring.api.purchase_history.response.PurchaseHistoryCreateResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class PurchaseHistoryService {
+	private final PurchaseHistoryRepository repository;
+	private final PortFolioHoldingRepository portFolioHoldingRepository;
+
+	@Transactional
+	public PurchaseHistoryCreateResponse addPurchaseHistory(PurchaseHistoryCreateRequest request,
+		Long portfolioHoldingId,
+		AuthMember authMember) {
+		log.info("매입이력 추가 서비스 요청 : request={}, portfolioHoldingId={}", request, portfolioHoldingId);
+		PortfolioHolding portfolioHolding = findPortfolioHolding(portfolioHoldingId);
+		validatePortfolioAuthorization(portfolioHolding.getPortfolio(), authMember.getMemberId());
+		PurchaseHistory savePurchaseHistory = repository.save(request.toEntity(portfolioHolding));
+		return PurchaseHistoryCreateResponse.from(savePurchaseHistory);
+	}
+
+	private PortfolioHolding findPortfolioHolding(Long portfolioHoldingId) {
+		return portFolioHoldingRepository.findById(portfolioHoldingId)
+			.orElseThrow(() -> new NotFoundResourceException(PortfolioHoldingErrorCode.NOT_FOUND_PORTFOLIO_HOLDING));
+	}
+
+	private void validatePortfolioAuthorization(Portfolio portfolio, Long memberId) {
+		if (!portfolio.hasAuthorization(memberId)) {
+			throw new ForBiddenException(PortfolioErrorCode.NOT_HAVE_AUTHORIZATION);
+		}
+	}
+}

--- a/fineAnts_app/src/main/java/codesquad/fineants/spring/api/purchase_history/request/PurchaseHistoryCreateRequest.java
+++ b/fineAnts_app/src/main/java/codesquad/fineants/spring/api/purchase_history/request/PurchaseHistoryCreateRequest.java
@@ -7,9 +7,14 @@ import javax.validation.constraints.Positive;
 
 import codesquad.fineants.domain.portfolio_holding.PortfolioHolding;
 import codesquad.fineants.domain.purchase_history.PurchaseHistory;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+@Getter
 @ToString
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PurchaseHistoryCreateRequest {
 	@NotNull(message = "매입날짜는 날짜 형식의 필수 정보입니다")
 	private LocalDateTime purchaseDate;

--- a/fineAnts_app/src/main/java/codesquad/fineants/spring/api/purchase_history/request/PurchaseHistoryCreateRequest.java
+++ b/fineAnts_app/src/main/java/codesquad/fineants/spring/api/purchase_history/request/PurchaseHistoryCreateRequest.java
@@ -1,0 +1,33 @@
+package codesquad.fineants.spring.api.purchase_history.request;
+
+import java.time.LocalDateTime;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+
+import codesquad.fineants.domain.portfolio_holding.PortfolioHolding;
+import codesquad.fineants.domain.purchase_history.PurchaseHistory;
+import lombok.ToString;
+
+@ToString
+public class PurchaseHistoryCreateRequest {
+	@NotNull(message = "매입날짜는 날짜 형식의 필수 정보입니다")
+	private LocalDateTime purchaseDate;
+	@NotNull(message = "매입 개수 정보는 필수 정보입니다")
+	@Positive(message = "주식 개수는 양수여야 합니다")
+	private Long numShares;
+	@NotNull(message = "매입가는 필수 정보입니다")
+	@Positive(message = "매입가는 양수여야 합니다")
+	private Long purchasePricePerShare;
+	private String memo;
+
+	public PurchaseHistory toEntity(PortfolioHolding portfolioHolding) {
+		return PurchaseHistory.builder()
+			.purchaseDate(purchaseDate)
+			.numShares(numShares)
+			.purchasePricePerShare(purchasePricePerShare)
+			.memo(memo)
+			.portFolioHolding(portfolioHolding)
+			.build();
+	}
+}

--- a/fineAnts_app/src/main/java/codesquad/fineants/spring/api/purchase_history/response/PurchaseHistoryCreateResponse.java
+++ b/fineAnts_app/src/main/java/codesquad/fineants/spring/api/purchase_history/response/PurchaseHistoryCreateResponse.java
@@ -1,0 +1,14 @@
+package codesquad.fineants.spring.api.purchase_history.response;
+
+import codesquad.fineants.domain.purchase_history.PurchaseHistory;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PurchaseHistoryCreateResponse {
+	private Long id;
+
+	public static PurchaseHistoryCreateResponse from(PurchaseHistory purchaseHistory) {
+		return new PurchaseHistoryCreateResponse(purchaseHistory.getId());
+	}
+}

--- a/fineAnts_app/src/main/java/codesquad/fineants/spring/api/success/code/PurchaseHistorySuccessCode.java
+++ b/fineAnts_app/src/main/java/codesquad/fineants/spring/api/success/code/PurchaseHistorySuccessCode.java
@@ -1,4 +1,4 @@
-package codesquad.fineants.spring.api.errors.errorcode;
+package codesquad.fineants.spring.api.success.code;
 
 import org.springframework.http.HttpStatus;
 
@@ -7,16 +7,15 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum PortfolioStockErrorCode implements ErrorCode {
-
-	NOT_FOUND_PORTFOLIO_STOCK(HttpStatus.NOT_FOUND, "포트폴리오 종목이 존재하지 않습니다");
+public enum PurchaseHistorySuccessCode implements SuccessCode {
+	CREATED_ADD_PURCHASE_HISTORY(HttpStatus.CREATED, "매입 이력이 추가되었습니다");
 
 	private final HttpStatus httpStatus;
 	private final String message;
 
 	@Override
 	public String toString() {
-		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "포트폴리오 에러 코드",
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "매입이력 성공 코드",
 			this.getClass().getSimpleName(),
 			name(),
 			httpStatus,

--- a/fineAnts_app/src/test/java/codesquad/fineants/domain/portfolio/PortfolioTest.java
+++ b/fineAnts_app/src/test/java/codesquad/fineants/domain/portfolio/PortfolioTest.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
 
 import codesquad.fineants.domain.portfolio_holding.PortfolioHolding;
 import codesquad.fineants.domain.purchase_history.PurchaseHistory;
@@ -14,6 +15,7 @@ import codesquad.fineants.domain.stock.Market;
 import codesquad.fineants.domain.stock.Stock;
 import codesquad.fineants.domain.stock_dividend.StockDividend;
 
+@ActiveProfiles("test")
 class PortfolioTest {
 
 	@DisplayName("포트폴리오의 총 손익을 계산한다")

--- a/fineAnts_app/src/test/java/codesquad/fineants/domain/portfolio_gain_history/PortfolioGainHistoryRepositoryTest.java
+++ b/fineAnts_app/src/test/java/codesquad/fineants/domain/portfolio_gain_history/PortfolioGainHistoryRepositoryTest.java
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class PortfolioGainHistoryRepositoryTest {
 

--- a/fineAnts_app/src/test/java/codesquad/fineants/domain/portfolio_holding/PortfolioHoldingTest.java
+++ b/fineAnts_app/src/test/java/codesquad/fineants/domain/portfolio_holding/PortfolioHoldingTest.java
@@ -6,9 +6,11 @@ import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
 
 import codesquad.fineants.domain.purchase_history.PurchaseHistory;
 
+@ActiveProfiles("test")
 class PortfolioHoldingTest {
 
 	@DisplayName("한 종목의 총 투자 금액을 계산한다")

--- a/fineAnts_app/src/test/java/codesquad/fineants/domain/purchase_history/PurchaseHistoryTest.java
+++ b/fineAnts_app/src/test/java/codesquad/fineants/domain/purchase_history/PurchaseHistoryTest.java
@@ -6,7 +6,9 @@ import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 class PurchaseHistoryTest {
 
 	@DisplayName("매입 내역의 투자 금액을 구한다")

--- a/fineAnts_app/src/test/java/codesquad/fineants/spring/api/portfolio/PortFolioServiceTest.java
+++ b/fineAnts_app/src/test/java/codesquad/fineants/spring/api/portfolio/PortFolioServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -34,6 +35,7 @@ import codesquad.fineants.spring.api.portfolio.request.PortfolioModifyRequest;
 import codesquad.fineants.spring.api.portfolio.response.PortFolioCreateResponse;
 import codesquad.fineants.spring.api.portfolio.response.PortfoliosResponse;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class PortFolioServiceTest {
 	@Autowired
@@ -275,44 +277,6 @@ class PortFolioServiceTest {
 			() -> assertThat(response).extracting("portfolios")
 				.asList()
 				.hasSize(10)
-		);
-	}
-
-	@DisplayName("사용자가 나의 포트폴리오들을 스크롤하여 조회한다")
-	@Test
-	void readMyAllPortfolioWithNextCursor() {
-		// given
-		List<Portfolio> portfolios = new ArrayList<>();
-		for (int i = 1; i <= 25; i++) {
-			portfolios.add(Portfolio.builder()
-				.name("내꿈은 워렌버핏" + i)
-				.securitiesFirm("토스")
-				.budget(1000000L)
-				.targetGain(1500000L)
-				.maximumLoss(900000L)
-				.member(member)
-				.build());
-		}
-		portfolioRepository.saveAll(portfolios);
-		int size = 10;
-		Long nextCursor = 16L;
-
-		// when
-		PortfoliosResponse response = service.readMyAllPortfolio(AuthMember.from(member), size, nextCursor);
-		assertAll(
-			() -> assertThat(response).extracting("nextCursor").isEqualTo(6L),
-			() -> assertThat(response).extracting("portfolios")
-				.asList()
-				.hasSize(10)
-		);
-
-		nextCursor = 6L;
-		PortfoliosResponse response2 = service.readMyAllPortfolio(AuthMember.from(member), size, nextCursor);
-		assertAll(
-			() -> assertThat(response2).extracting("nextCursor").isEqualTo(null),
-			() -> assertThat(response2).extracting("portfolios")
-				.asList()
-				.hasSize(5)
 		);
 	}
 }

--- a/fineAnts_app/src/test/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryRestControllerTest.java
+++ b/fineAnts_app/src/test/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryRestControllerTest.java
@@ -1,0 +1,167 @@
+package codesquad.fineants.spring.api.purchase_history;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import codesquad.fineants.domain.member.Member;
+import codesquad.fineants.domain.oauth.support.AuthMember;
+import codesquad.fineants.domain.oauth.support.AuthPrincipalArgumentResolver;
+import codesquad.fineants.domain.portfolio.Portfolio;
+import codesquad.fineants.domain.portfolio_holding.PortfolioHolding;
+import codesquad.fineants.domain.stock.Market;
+import codesquad.fineants.domain.stock.Stock;
+import codesquad.fineants.spring.api.errors.handler.GlobalExceptionHandler;
+import codesquad.fineants.spring.config.JpaAuditingConfiguration;
+
+@ActiveProfiles("test")
+@WebMvcTest(controllers = PurchaseHistoryRestController.class)
+@MockBean(JpaAuditingConfiguration.class)
+class PurchaseHistoryRestControllerTest {
+
+	private MockMvc mockMvc;
+
+	@Autowired
+	private PurchaseHistoryRestController purchaseHistoryRestController;
+
+	@Autowired
+	private GlobalExceptionHandler globalExceptionHandler;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private AuthPrincipalArgumentResolver authPrincipalArgumentResolver;
+
+	@MockBean
+	private PurchaseHistoryService purchaseHistoryService;
+
+	private Member member;
+	private Portfolio portfolio;
+	private Stock stock;
+
+	private PortfolioHolding portfolioHolding;
+
+	@BeforeEach
+	void setup() {
+		mockMvc = MockMvcBuilders.standaloneSetup(purchaseHistoryRestController)
+			.setControllerAdvice(globalExceptionHandler)
+			.setCustomArgumentResolvers(authPrincipalArgumentResolver)
+			.alwaysDo(print())
+			.build();
+
+		given(authPrincipalArgumentResolver.supportsParameter(any())).willReturn(true);
+
+		member = Member.builder()
+			.id(1L)
+			.nickname("일개미1234")
+			.email("kim1234@gmail.com")
+			.provider("local")
+			.password("kim1234@")
+			.profileUrl("profileValue")
+			.build();
+
+		AuthMember authMember = AuthMember.from(member);
+
+		given(authPrincipalArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(authMember);
+
+		portfolio = Portfolio.builder()
+			.id(1L)
+			.name("내꿈은 워렌버핏")
+			.securitiesFirm("토스")
+			.budget(1000000L)
+			.targetGain(1500000L)
+			.maximumLoss(900000L)
+			.member(member)
+			.build();
+
+		stock = Stock.builder()
+			.id(1L)
+			.companyName("삼성전자보통주")
+			.tickerSymbol("005930")
+			.companyNameEng("SamsungElectronics")
+			.stockCode("KR7005930003")
+			.market(Market.KOSPI)
+			.build();
+
+		portfolioHolding = PortfolioHolding.builder()
+			.id(1L)
+			.numShares(0L)
+			.annualDividend(0L)
+			.currentPrice(null)
+			.portfolio(portfolio)
+			.stock(stock)
+			.build();
+	}
+
+	@DisplayName("사용자가 매입 이력을 추가한다")
+	@Test
+	void addPurchaseHistory() throws Exception {
+		// given
+		String url = String.format("/api/portfolio/%d/holdings/%d/purchaseHistory", portfolio.getId(),
+			portfolioHolding.getId());
+		Map<String, Object> requestBody = new HashMap<>();
+		requestBody.put("purchaseDate", LocalDateTime.now().toString());
+		requestBody.put("numShares", 3);
+		requestBody.put("purchasePricePerShare", 50000);
+		requestBody.put("memo", "첫구매");
+
+		String body = objectMapper.writeValueAsString(requestBody);
+		// when & then
+		mockMvc.perform(post(url)
+				.contentType(MediaType.APPLICATION_JSON)
+				.characterEncoding(StandardCharsets.UTF_8)
+				.content(body))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("code").value(equalTo(201)))
+			.andExpect(jsonPath("status").value(equalTo("Created")))
+			.andExpect(jsonPath("message").value(equalTo("매입 이력이 추가되었습니다")))
+			.andExpect(jsonPath("data").value(equalTo(null)));
+	}
+
+	@DisplayName("사용자가 매입 이력 추가시 유효하지 않은 입력으로 추가할 수 없다")
+	@Test
+	void addPurchaseHistoryWithInvalidInput() throws Exception {
+		// given
+		String url = String.format("/api/portfolio/%d/holdings/%d/purchaseHistory", portfolio.getId(),
+			portfolioHolding.getId());
+		Map<String, Object> requestBody = new HashMap<>();
+		requestBody.put("purchaseDate", null);
+		requestBody.put("numShares", 0);
+		requestBody.put("purchasePricePerShare", 0);
+		requestBody.put("memo", "첫구매");
+
+		String body = objectMapper.writeValueAsString(requestBody);
+		// when & then
+		mockMvc.perform(post(url)
+				.contentType(MediaType.APPLICATION_JSON)
+				.characterEncoding(StandardCharsets.UTF_8)
+				.content(body))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("code").value(equalTo(400)))
+			.andExpect(jsonPath("status").value(equalTo("Bad Request")))
+			.andExpect(jsonPath("message").value(equalTo("잘못된 입력형식입니다")))
+			.andExpect(jsonPath("data").isArray());
+	}
+}

--- a/fineAnts_app/src/test/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryServiceTest.java
+++ b/fineAnts_app/src/test/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryServiceTest.java
@@ -1,0 +1,134 @@
+package codesquad.fineants.spring.api.purchase_history;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import codesquad.fineants.domain.member.Member;
+import codesquad.fineants.domain.member.MemberRepository;
+import codesquad.fineants.domain.oauth.support.AuthMember;
+import codesquad.fineants.domain.portfolio.Portfolio;
+import codesquad.fineants.domain.portfolio.PortfolioRepository;
+import codesquad.fineants.domain.portfolio_holding.PortFolioHoldingRepository;
+import codesquad.fineants.domain.portfolio_holding.PortfolioHolding;
+import codesquad.fineants.domain.purchase_history.PurchaseHistoryRepository;
+import codesquad.fineants.domain.stock.Market;
+import codesquad.fineants.domain.stock.Stock;
+import codesquad.fineants.domain.stock.StockRepository;
+import codesquad.fineants.spring.api.purchase_history.request.PurchaseHistoryCreateRequest;
+import codesquad.fineants.spring.api.purchase_history.response.PurchaseHistoryCreateResponse;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class PurchaseHistoryServiceTest {
+
+	@Autowired
+	private PortFolioHoldingRepository portFolioHoldingRepository;
+
+	@Autowired
+	private PortfolioRepository portfolioRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private StockRepository stockRepository;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private PurchaseHistoryRepository purchaseHistoryRepository;
+
+	@Autowired
+	private PurchaseHistoryService service;
+
+	private Member member;
+
+	private Portfolio portfolio;
+
+	private Stock stock;
+
+	private PortfolioHolding portfolioHolding;
+
+	@BeforeEach
+	void init() {
+		Member member = Member.builder()
+			.nickname("일개미1234")
+			.email("kim1234@gmail.com")
+			.password("kim1234@")
+			.provider("local")
+			.build();
+		this.member = memberRepository.save(member);
+
+		Portfolio portfolio = Portfolio.builder()
+			.name("내꿈은 워렌버핏")
+			.securitiesFirm("토스")
+			.budget(1000000L)
+			.targetGain(1500000L)
+			.maximumLoss(900000L)
+			.member(member)
+			.build();
+		this.portfolio = portfolioRepository.save(portfolio);
+
+		Stock stock = Stock.builder()
+			.companyName("삼성전자보통주")
+			.tickerSymbol("005930")
+			.companyNameEng("SamsungElectronics")
+			.stockCode("KR7005930003")
+			.market(Market.KOSPI)
+			.build();
+		this.stock = stockRepository.save(stock);
+
+		PortfolioHolding portfolioHolding = PortfolioHolding.empty(portfolio, stock);
+		this.portfolioHolding = portFolioHoldingRepository.save(portfolioHolding);
+	}
+
+	@AfterEach
+	void tearDown() {
+		purchaseHistoryRepository.deleteAllInBatch();
+		portFolioHoldingRepository.deleteAllInBatch();
+		portfolioRepository.deleteAllInBatch();
+		memberRepository.deleteAllInBatch();
+		stockRepository.deleteAllInBatch();
+	}
+
+	@DisplayName("사용자는 매입 이력을 추가한다")
+	@Test
+	void addPurchaseHistory() throws JsonProcessingException {
+		// given
+		Map<String, Object> requestBody = new HashMap<>();
+		requestBody.put("purchaseDate", LocalDateTime.now());
+		requestBody.put("numShares", 3L);
+		requestBody.put("purchasePricePerShare", 50000);
+		requestBody.put("memo", "첫구매");
+
+		PurchaseHistoryCreateRequest request = objectMapper.readValue(
+			objectMapper.writeValueAsString(requestBody), PurchaseHistoryCreateRequest.class);
+		Long portfolioHoldingId = portfolioHolding.getId();
+		// when
+		PurchaseHistoryCreateResponse response = service.addPurchaseHistory(request,
+			portfolioHoldingId, AuthMember.from(member));
+
+		// then
+
+		Assertions.assertAll(
+			() -> assertThat(response).extracting("id").isNotNull(),
+			() -> assertThat(purchaseHistoryRepository.findAll()).hasSize(1)
+		);
+	}
+}


### PR DESCRIPTION
## 구현한 것

- 매입 이력 추가 서비스를 구현하였습니다.
- url : /api/portfolio/:portfolioId/holdings/:portfolioHoldingId/purchaseHistory

