### PR TITLE
[fix] 포트폴리오 목록 조회 및 상세 조회 수정 (#88)

### DIFF
--- a/fineAnts_app/src/main/java/codesquad/fineants/spring/api/kis/KisService.java
+++ b/fineAnts_app/src/main/java/codesquad/fineants/spring/api/kis/KisService.java
@@ -1,11 +1,15 @@
 package codesquad.fineants.spring.api.kis;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -26,8 +30,9 @@ public class KisService {
 
 	private static final String SUBSCRIBE_CURRENT_PRICE = "/sub/currentPrice/";
 	private static final String SUBSCRIBE_PORTFOLIO_HOLDING_FORMAT = "/sub/portfolio/%d/currentPrice/%s";
-	private static final Map<String, Long> currentPriceMap = new ConcurrentHashMap<>();
+	public static final Map<String, Long> currentPriceMap = new ConcurrentHashMap<>();
 	private static final Set<PortfolioSubscription> portfolioSubscriptions = new HashSet<>();
+	private static final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(5);
 	private final KisClient kisClient;
 	private final KisRedisService redisService;
 	private final KisClientScheduler scheduler;
@@ -93,5 +98,23 @@ public class KisService {
 	private boolean checkCurrentPriceMap(List<String> tickerSymbols) {
 		return tickerSymbols.stream()
 			.noneMatch(tickerSymbol -> currentPriceMap.getOrDefault(tickerSymbol, 0L) == 0L);
+	}
+
+	public Map<String, Long> refreshCurrentPriceMap(List<String> tickerSymbols) {
+		tickerSymbols.parallelStream()
+			.filter(tickerSymbol -> !redisService.hasCurrentPrice(tickerSymbol))
+			.forEach(tickerSymbol -> executorService.schedule(createCurrentPriceRequest(tickerSymbol), 200L,
+				TimeUnit.MILLISECONDS));
+
+		executorService.shutdown();
+		try {
+			if (executorService.awaitTermination(5L, TimeUnit.SECONDS)) {
+				executorService.shutdownNow();
+			}
+		} catch (InterruptedException e) {
+			executorService.shutdownNow();
+		}
+
+		return new HashMap<>(currentPriceMap);
 	}
 }

--- a/fineAnts_app/src/main/java/codesquad/fineants/spring/api/kis/KisStompEventListener.java
+++ b/fineAnts_app/src/main/java/codesquad/fineants/spring/api/kis/KisStompEventListener.java
@@ -1,0 +1,20 @@
+package codesquad.fineants.spring.api.kis;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class KisStompEventListener {
+	@EventListener
+	public void handleDisconnectEvent(SessionDisconnectEvent event) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+		String sessionId = accessor.getSessionId();
+		log.info("handleDisconnectEvent : {}", sessionId);
+		// 연결이 종료된 세션에 대한 추가 처리를 수행합니다.
+	}
+}

--- a/fineAnts_app/src/main/java/codesquad/fineants/spring/api/portfolio/PortFolioService.java
+++ b/fineAnts_app/src/main/java/codesquad/fineants/spring/api/portfolio/PortFolioService.java
@@ -1,6 +1,7 @@
 package codesquad.fineants.spring.api.portfolio;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -21,12 +22,14 @@ import codesquad.fineants.domain.portfolio_gain_history.PortfolioGainHistoryRepo
 import codesquad.fineants.domain.portfolio_holding.PortFolioHoldingRepository;
 import codesquad.fineants.domain.portfolio_holding.PortfolioHolding;
 import codesquad.fineants.domain.purchase_history.PurchaseHistoryRepository;
+import codesquad.fineants.domain.stock.Stock;
 import codesquad.fineants.spring.api.errors.errorcode.MemberErrorCode;
 import codesquad.fineants.spring.api.errors.errorcode.PortfolioErrorCode;
 import codesquad.fineants.spring.api.errors.exception.BadRequestException;
 import codesquad.fineants.spring.api.errors.exception.ConflictException;
 import codesquad.fineants.spring.api.errors.exception.ForBiddenException;
 import codesquad.fineants.spring.api.errors.exception.NotFoundResourceException;
+import codesquad.fineants.spring.api.kis.KisService;
 import codesquad.fineants.spring.api.portfolio.request.PortfolioCreateRequest;
 import codesquad.fineants.spring.api.portfolio.request.PortfolioModifyRequest;
 import codesquad.fineants.spring.api.portfolio.response.PortFolioCreateResponse;
@@ -46,6 +49,7 @@ public class PortFolioService {
 	private final PortFolioHoldingRepository portFolioHoldingRepository;
 	private final PurchaseHistoryRepository purchaseHistoryRepository;
 	private final PortfolioGainHistoryRepository portfolioGainHistoryRepository;
+	private final KisService kisService;
 
 	@Transactional
 	public PortFolioCreateResponse addPortFolio(PortfolioCreateRequest request, AuthMember authMember) {
@@ -151,6 +155,15 @@ public class PortFolioService {
 		ScrollPaginationCollection<Portfolio> portfoliosCursor = ScrollPaginationCollection.of(
 			portfolios, size);
 
-		return PortfoliosResponse.of(portfoliosCursor, portfolioGainHistoryMap);
+		List<String> tickerSymbols = portfolios.stream()
+			.map(Portfolio::getPortfolioHoldings)
+			.flatMap(Collection::stream)
+			.map(PortfolioHolding::getStock)
+			.map(Stock::getTickerSymbol)
+			.distinct()
+			.collect(Collectors.toList());
+		Map<String, Long> currentPriceMap = kisService.refreshCurrentPriceMap(tickerSymbols);
+
+		return PortfoliosResponse.of(portfoliosCursor, portfolioGainHistoryMap, currentPriceMap);
 	}
 }

--- a/fineAnts_app/src/main/java/codesquad/fineants/spring/api/portfolio/response/PortfoliosResponse.java
+++ b/fineAnts_app/src/main/java/codesquad/fineants/spring/api/portfolio/response/PortfoliosResponse.java
@@ -17,32 +17,37 @@ public class PortfoliosResponse {
 	private final Long nextCursor;
 
 	public static PortfoliosResponse of(ScrollPaginationCollection<Portfolio> portfoliosScroll,
-		Map<Portfolio, PortfolioGainHistory> portfolioGainHistoryMap) {
+		Map<Portfolio, PortfolioGainHistory> portfolioGainHistoryMap, Map<String, Long> currentPriceMap) {
 		if (portfoliosScroll.isLastScroll()) {
-			return PortfoliosResponse.newLastScroll(portfoliosScroll.getCurrentScrollItems(), portfolioGainHistoryMap);
+			return PortfoliosResponse.newLastScroll(portfoliosScroll.getCurrentScrollItems(), portfolioGainHistoryMap,
+				currentPriceMap);
 		}
 		return newScrollHasNext(portfoliosScroll.getCurrentScrollItems(), portfolioGainHistoryMap,
-			portfoliosScroll.getNextCursor().getId());
+			portfoliosScroll.getNextCursor().getId(), currentPriceMap);
 	}
 
 	private static PortfoliosResponse newLastScroll(List<Portfolio> portfolios,
-		Map<Portfolio, PortfolioGainHistory> portfolioGainHistoryMap) {
-		return newScrollHasNext(portfolios, portfolioGainHistoryMap, null);
+		Map<Portfolio, PortfolioGainHistory> portfolioGainHistoryMap, Map<String, Long> currentPriceMap) {
+		return newScrollHasNext(portfolios, portfolioGainHistoryMap, null, currentPriceMap);
 	}
 
 	private static PortfoliosResponse newScrollHasNext(List<Portfolio> portfolios,
 		Map<Portfolio, PortfolioGainHistory> portfolioGainHistoryMap,
-		Long nextCursor) {
+		Long nextCursor, Map<String, Long> currentPriceMap) {
 		if (nextCursor != null) {
-			return new PortfoliosResponse(getContents(portfolios, portfolioGainHistoryMap), true, nextCursor);
+			return new PortfoliosResponse(getContents(portfolios, portfolioGainHistoryMap, currentPriceMap), true,
+				nextCursor);
 		}
-		return new PortfoliosResponse(getContents(portfolios, portfolioGainHistoryMap), false, null);
+		return new PortfoliosResponse(getContents(portfolios, portfolioGainHistoryMap, currentPriceMap), false, null);
 	}
 
 	private static List<PortFolioItem> getContents(List<Portfolio> portfolios,
-		Map<Portfolio, PortfolioGainHistory> portfolioGainHistoryMap) {
+		Map<Portfolio, PortfolioGainHistory> portfolioGainHistoryMap, Map<String, Long> currentPriceMap) {
 		return portfolios.stream()
-			.map(portfolio -> PortFolioItem.of(portfolio, portfolioGainHistoryMap.get(portfolio)))
+			.map(portfolio -> {
+				portfolio.changeCurrentPriceFromHoldings(currentPriceMap);
+				return PortFolioItem.of(portfolio, portfolioGainHistoryMap.get(portfolio));
+			})
 			.collect(Collectors.toList());
 	}
 }

--- a/fineAnts_app/src/main/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioStockService.java
+++ b/fineAnts_app/src/main/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioStockService.java
@@ -57,7 +57,7 @@ public class PortfolioStockService {
 		return PortfolioStockCreateResponse.from(portFolioHolding);
 	}
 
-	private Portfolio findPortfolio(Long portfolioId) {
+	public Portfolio findPortfolio(Long portfolioId) {
 		return portfolioRepository.findById(portfolioId)
 			.orElseThrow(() -> new NotFoundResourceException(PortfolioErrorCode.NOT_FOUND_PORTFOLIO));
 	}
@@ -87,7 +87,7 @@ public class PortfolioStockService {
 
 	public PortfolioHoldingsResponse readMyPortfolioStocks(Long portfolioId) {
 		Portfolio portfolio = findPortfolio(portfolioId);
-		List<PortfolioHolding> portfolioHoldings = portFolioHoldingRepository.findAllByPortfolio(portfolio);
+		List<PortfolioHolding> portfolioHoldings = portfolio.getPortfolioHoldings();
 		PortfolioGainHistory latestHistory = portfolioGainHistoryRepository.findFirstByPortfolioAndCreateAtIsLessThanEqualOrderByCreateAtDesc(
 				portfolio, LocalDateTime.now())
 			.orElseGet(PortfolioGainHistory::empty);

--- a/fineAnts_app/src/main/java/codesquad/fineants/spring/api/portfolio_stock/response/PurchaseHistoryItem.java
+++ b/fineAnts_app/src/main/java/codesquad/fineants/spring/api/portfolio_stock/response/PurchaseHistoryItem.java
@@ -8,7 +8,7 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PurchaseHistoryItem {
-	private Long id;
+	private Long purchaseHistoryId;
 	private LocalDateTime purchaseDate;
 	private Long numShares;
 	private Double purchasePricePerShare;


### PR DESCRIPTION
* [feat] 웹소켓 주식 현재가 시세 연결 (#74)

* [feat] 포트폴리오 추가 서비스 구현 (#32)

* #2 feat: 프로젝트 초기화 (#12)

* #6 chore: jwt 관련 라이브러리 추가

* #6 docs: gitignore에 푸시하지 말아야할 파일들 추가

* #6 docs: 로컬 환경 docker-compose.yml 추가

* #2 docs: applicatoin.yml 파일 설정 및 로그백 파일 추가

* #6 feat: 회원 엔티티 구현

* #6 feat: 에러관련 코드, 예외, 핸들러 추가

* #6 feat: 소셜 로그인 서비스 구현

* #6 rename: oauth 파일 이동

* #6 feat: Oauth 로그인 서비스 구현

* #6 feat: 로그아웃 및 액세스 토큰 갱신 구현

* [feat] 소셜 로그인 및 로그아웃 서비스 구현 (#14)

* #6 chore: jwt 관련 라이브러리 추가

* #6 docs: gitignore에 푸시하지 말아야할 파일들 추가

* #6 docs: 로컬 환경 docker-compose.yml 추가

* #2 docs: applicatoin.yml 파일 설정 및 로그백 파일 추가

* #6 feat: 회원 엔티티 구현

* #6 feat: 에러관련 코드, 예외, 핸들러 추가

* #6 feat: 소셜 로그인 서비스 구현

* #6 rename: oauth 파일 이동

* #6 feat: Oauth 로그인 서비스 구현

* #6 feat: 로그아웃 및 액세스 토큰 갱신 구현

* #9 feat: 한국투자 증권 open api 연결

* #9 test: 한국투자 증권 open api 연결 테스트 작성

* #9 feat: 실시간 체결가 웹소켓 연결 구현

* #9 feat: stomp 추가

* #10 feat: 종목 엔티티 구현

* #15 feat: 포트폴리오 엔티티 구현

* #15 feat: 포트폴리오 엔티티 구현

* #15 feat: 포트폴리오 추가 서비스 구현

* #15 test: 포트롤리오 추가 서비스 테스트 추가

* #15 test: 포트폴리오 추가 컨트롤러 테스트 코드 작성

* #15 test: 포트폴리오 추가 입력형식 테스트 코드 추가

* #15 feat: 포트폴리오 추가시 동일한 이름 중복 검증 처리

* #15 test: 포트폴리오 추가시 동일한 이름 중복 검증 처리 테스트 코드 작성

* [feat] 포트폴리오 수정 및 삭제 서비스 구현 (#33)

* #2 feat: 프로젝트 초기화 (#12)

* #6 chore: jwt 관련 라이브러리 추가

* #6 docs: gitignore에 푸시하지 말아야할 파일들 추가

* #6 docs: 로컬 환경 docker-compose.yml 추가

* #2 docs: applicatoin.yml 파일 설정 및 로그백 파일 추가

* #6 feat: 회원 엔티티 구현

* #6 feat: 에러관련 코드, 예외, 핸들러 추가

* #6 feat: 소셜 로그인 서비스 구현

* #6 rename: oauth 파일 이동

* #6 feat: Oauth 로그인 서비스 구현

* #6 feat: 로그아웃 및 액세스 토큰 갱신 구현

* [feat] 소셜 로그인 및 로그아웃 서비스 구현 (#14)

* #6 chore: jwt 관련 라이브러리 추가

* #6 docs: gitignore에 푸시하지 말아야할 파일들 추가

* #6 docs: 로컬 환경 docker-compose.yml 추가

* #2 docs: applicatoin.yml 파일 설정 및 로그백 파일 추가

* #6 feat: 회원 엔티티 구현

* #6 feat: 에러관련 코드, 예외, 핸들러 추가

* #6 feat: 소셜 로그인 서비스 구현

* #6 rename: oauth 파일 이동

* #6 feat: Oauth 로그인 서비스 구현

* #6 feat: 로그아웃 및 액세스 토큰 갱신 구현

* #9 feat: 한국투자 증권 open api 연결

* #9 test: 한국투자 증권 open api 연결 테스트 작성

* #9 feat: 실시간 체결가 웹소켓 연결 구현

* #9 feat: stomp 추가

* #10 feat: 종목 엔티티 구현

* #15 feat: 포트폴리오 엔티티 구현

* #15 feat: 포트폴리오 엔티티 구현

* #15 feat: 포트폴리오 추가 서비스 구현

* #15 test: 포트롤리오 추가 서비스 테스트 추가

* #15 test: 포트폴리오 추가 컨트롤러 테스트 코드 작성

* #15 test: 포트폴리오 추가 입력형식 테스트 코드 추가

* #15 feat: 포트폴리오 추가시 동일한 이름 중복 검증 처리

* #15 test: 포트폴리오 추가시 동일한 이름 중복 검증 처리 테스트 코드 작성

* #17 feat: 포트폴리오 수정 및 삭제 서비스 구현

* #17 test: 포트폴리오 수정 및 삭제에 대한 테스트 코드 작성

* #17 style: 코드 정리

* [feat] 포트폴리오 종목 추가 및 삭제 서비스 구현 (#43)

* [feat] 포트폴리오 추가 서비스 구현 (#32)

* #2 feat: 프로젝트 초기화 (#12)

* #6 chore: jwt 관련 라이브러리 추가

* #6 docs: gitignore에 푸시하지 말아야할 파일들 추가

* #6 docs: 로컬 환경 docker-compose.yml 추가

* #2 docs: applicatoin.yml 파일 설정 및 로그백 파일 추가

* #6 feat: 회원 엔티티 구현

* #6 feat: 에러관련 코드, 예외, 핸들러 추가

* #6 feat: 소셜 로그인 서비스 구현

* #6 rename: oauth 파일 이동

* #6 feat: Oauth 로그인 서비스 구현

* #6 feat: 로그아웃 및 액세스 토큰 갱신 구현

* [feat] 소셜 로그인 및 로그아웃 서비스 구현 (#14)

* #6 chore: jwt 관련 라이브러리 추가

* #6 docs: gitignore에 푸시하지 말아야할 파일들 추가

* #6 docs: 로컬 환경 docker-compose.yml 추가

* #2 docs: applicatoin.yml 파일 설정 및 로그백 파일 추가

* #6 feat: 회원 엔티티 구현

* #6 feat: 에러관련 코드, 예외, 핸들러 추가

* #6 feat: 소셜 로그인 서비스 구현

* #6 rename: oauth 파일 이동

* #6 feat: Oauth 로그인 서비스 구현

* #6 feat: 로그아웃 및 액세스 토큰 갱신 구현

* #9 feat: 한국투자 증권 open api 연결

* #9 test: 한국투자 증권 open api 연결 테스트 작성

* #9 feat: 실시간 체결가 웹소켓 연결 구현

* #9 feat: stomp 추가

* #10 feat: 종목 엔티티 구현

* #15 feat: 포트폴리오 엔티티 구현

* #15 feat: 포트폴리오 엔티티 구현

* #15 feat: 포트폴리오 추가 서비스 구현

* #15 test: 포트롤리오 추가 서비스 테스트 추가

* #15 test: 포트폴리오 추가 컨트롤러 테스트 코드 작성

* #15 test: 포트폴리오 추가 입력형식 테스트 코드 추가

* #15 feat: 포트폴리오 추가시 동일한 이름 중복 검증 처리

* #15 test: 포트폴리오 추가시 동일한 이름 중복 검증 처리 테스트 코드 작성

* [feat] 포트폴리오 수정 및 삭제 서비스 구현 (#33)

* #2 feat: 프로젝트 초기화 (#12)

* #6 chore: jwt 관련 라이브러리 추가

* #6 docs: gitignore에 푸시하지 말아야할 파일들 추가

* #6 docs: 로컬 환경 docker-compose.yml 추가

* #2 docs: applicatoin.yml 파일 설정 및 로그백 파일 추가

* #6 feat: 회원 엔티티 구현

* #6 feat: 에러관련 코드, 예외, 핸들러 추가

* #6 feat: 소셜 로그인 서비스 구현

* #6 rename: oauth 파일 이동

* #6 feat: Oauth 로그인 서비스 구현

* #6 feat: 로그아웃 및 액세스 토큰 갱신 구현

* [feat] 소셜 로그인 및 로그아웃 서비스 구현 (#14)

* #6 chore: jwt 관련 라이브러리 추가

* #6 docs: gitignore에 푸시하지 말아야할 파일들 추가

* #6 docs: 로컬 환경 docker-compose.yml 추가

* #2 docs: applicatoin.yml 파일 설정 및 로그백 파일 추가

* #6 feat: 회원 엔티티 구현

* #6 feat: 에러관련 코드, 예외, 핸들러 추가

* #6 feat: 소셜 로그인 서비스 구현

* #6 rename: oauth 파일 이동

* #6 feat: Oauth 로그인 서비스 구현

* #6 feat: 로그아웃 및 액세스 토큰 갱신 구현

* #9 feat: 한국투자 증권 open api 연결

* #9 test: 한국투자 증권 open api 연결 테스트 작성

* #9 feat: 실시간 체결가 웹소켓 연결 구현

* #9 feat: stomp 추가

* #10 feat: 종목 엔티티 구현

* #15 feat: 포트폴리오 엔티티 구현

* #15 feat: 포트폴리오 엔티티 구현

* #15 feat: 포트폴리오 추가 서비스 구현

* #15 test: 포트롤리오 추가 서비스 테스트 추가

* #15 test: 포트폴리오 추가 컨트롤러 테스트 코드 작성

* #15 test: 포트폴리오 추가 입력형식 테스트 코드 추가

* #15 feat: 포트폴리오 추가시 동일한 이름 중복 검증 처리

* #15 test: 포트폴리오 추가시 동일한 이름 중복 검증 처리 테스트 코드 작성

* #17 feat: 포트폴리오 수정 및 삭제 서비스 구현

* #17 test: 포트폴리오 수정 및 삭제에 대한 테스트 코드 작성

* #17 style: 코드 정리

* [feat] CI/CD 설정 (#35)

* #7 docs: cicd 워크플로우 설정

- 빌드 설정 및 s3 업로드 설정

* #7 docs: cicd 설정

* #7 fix: appspec.yml 파일 오타 수정

* #7 fix: appspec.yml 파일 오타 수정

* #7 fix: 버킷 이름 수정

* #7 fix: deploy 이름 삭제

- 버킷 이름에 /를 지정할 수 없음

* #16 feat: 포트폴리오 목록 조회 구현

* #16 feat: 포트폴리오 목록 조회 페이징 구현

* #16 feat: 포트폴리오 목록 조회시 hasNext를 응답하도록 구현

- nextCursor가 null인 경우 hasNext는 false로 응답하도록 구현하였습니다.

* #18 feat: 포트폴리오 종목 추가 서비스 구현

* #18 feat: 포트폴리오 종목 삭제 서비스 구현

* #18 style: 코드 정리

* [feat] 종목 검색 구현 (#45)

* [feat] 포트폴리오 추가 서비스 구현 (#32)

* #2 feat: 프로젝트 초기화 (#12)

* #6 chore: jwt 관련 라이브러리 추가

* #6 docs: gitignore에 푸시하지 말아야할 파일들 추가

* #6 docs: 로컬 환경 docker-compose.yml 추가

* #2 docs: applicatoin.yml 파일 설정 및 로그백 파일 추가

* #6 feat: 회원 엔티티 구현

* #6 feat: 에러관련 코드, 예외, 핸들러 추가

* #6 feat: 소셜 로그인 서비스 구현

* #6 rename: oauth 파일 이동

* #6 feat: Oauth 로그인 서비스 구현

* #6 feat: 로그아웃 및 액세스 토큰 갱신 구현

* [feat] 소셜 로그인 및 로그아웃 서비스 구현 (#14)

* #6 chore: jwt 관련 라이브러리 추가

* #6 docs: gitignore에 푸시하지 말아야할 파일들 추가

* #6 docs: 로컬 환경 docker-compose.yml 추가

* #2 docs: applicatoin.yml 파일 설정 및 로그백 파일 추가

* #6 feat: 회원 엔티티 구현

* #6 feat: 에러관련 코드, 예외, 핸들러 추가

* #6 feat: 소셜 로그인 서비스 구현

* #6 rename: oauth 파일 이동

* #6 feat: Oauth 로그인 서비스 구현

* #6 feat: 로그아웃 및 액세스 토큰 갱신 구현

* #9 feat: 한국투자 증권 open api 연결

* #9 test: 한국투자 증권 open api 연결 테스트 작성

* #9 feat: 실시간 체결가 웹소켓 연결 구현

* #9 feat: stomp 추가

* #10 feat: 종목 엔티티 구현

* #15 feat: 포트폴리오 엔티티 구현

* #15 feat: 포트폴리오 엔티티 구현

* #15 feat: 포트폴리오 추가 서비스 구현

* #15 test: 포트롤리오 추가 서비스 테스트 추가

* #15 test: 포트폴리오 추가 컨트롤러 테스트 코드 작성

* #15 test: 포트폴리오 추가 입력형식 테스트 코드 추가

* #15 feat: 포트폴리오 추가시 동일한 이름 중복 검증 처리

* #15 test: 포트폴리오 추가시 동일한 이름 중복 검증 처리 테스트 코드 작성

* [feat] 포트폴리오 수정 및 삭제 서비스 구현 (#33)

* #2 feat: 프로젝트 초기화 (#12)

* #6 chore: jwt 관련 라이브러리 추가

* #6 docs: gitignore에 푸시하지 말아야할 파일들 추가

* #6 docs: 로컬 환경 docker-compose.yml 추가

* #2 docs: applicatoin.yml 파일 설정 및 로그백 파일 추가

* #6 feat: 회원 엔티티 구현

* #6 feat: 에러관련 코드, 예외, 핸들러 추가

* #6 feat: 소셜 로그인 서비스 구현

* #6 rename: oauth 파일 이동

* #6 feat: Oauth 로그인 서비스 구현

* #6 feat: 로그아웃 및 액세스 토큰 갱신 구현

* [feat] 소셜 로그인 및 로그아웃 서비스 구현 (#14)

* #6 chore: jwt 관련 라이브러리 추가

* #6 docs: gitignore에 푸시하지 말아야할 파일들 추가

* #6 docs: 로컬 환경 docker-compose.yml 추가

* #2 docs: applicatoin.yml 파일 설정 및 로그백 파일 추가

* #6 feat: 회원 엔티티 구현

* #6 feat: 에러관련 코드, 예외, 핸들러 추가

* #6 feat: 소셜 로그인 서비스 구현

* #6 rename: oauth 파일 이동

* #6 feat: Oauth 로그인 서비스 구현

* #6 feat: 로그아웃 및 액세스 토큰 갱신 구현

* #9 feat: 한국투자 증권 open api 연결

* #9 test: 한국투자 증권 open api 연결 테스트 작성

* #9 feat: 실시간 체결가 웹소켓 연결 구현

* #9 feat: stomp 추가

* #10 feat: 종목 엔티티 구현

* #15 feat: 포트폴리오 엔티티 구현

* #15 feat: 포트폴리오 엔티티 구현

* #15 feat: 포트폴리오 추가 서비스 구현

* #15 test: 포트롤리오 추가 서비스 테스트 추가

* #15 test: 포트폴리오 추가 컨트롤러 테스트 코드 작성

* #15 test: 포트폴리오 추가 입력형식 테스트 코드 추가

* #15 feat: 포트폴리오 추가시 동일한 이름 중복 검증 처리

* #15 test: 포트폴리오 추가시 동일한 이름 중복 검증 처리 테스트 코드 작성

* #17 feat: 포트폴리오 수정 및 삭제 서비스 구현

* #17 test: 포트폴리오 수정 및 삭제에 대한 테스트 코드 작성

* #17 style: 코드 정리

* [feat] CI/CD 설정 (#35)

* #7 docs: cicd 워크플로우 설정

- 빌드 설정 및 s3 업로드 설정

* #7 docs: cicd 설정

* #7 fix: appspec.yml 파일 오타 수정

* #7 fix: appspec.yml 파일 오타 수정

* #7 fix: 버킷 이름 수정

* #7 fix: deploy 이름 삭제

- 버킷 이름에 /를 지정할 수 없음

* #16 feat: 포트폴리오 목록 조회 구현

* #16 feat: 포트폴리오 목록 조회 페이징 구현

* #16 feat: 포트폴리오 목록 조회시 hasNext를 응답하도록 구현

- nextCursor가 null인 경우 hasNext는 false로 응답하도록 구현하였습니다.

* #18 feat: 포트폴리오 종목 추가 서비스 구현

* #18 feat: 포트폴리오 종목 삭제 서비스 구현

* #18 style: 코드 정리

* #21 feat: 엘라스틱 서치 환경 구현

* #21 feat: 종목 검색 구현

* [feat] 포스트맨 변경 사항 반영 (#48)

* #48 fix: 포스트맨에 맞추어 응답 형식 변경

* #48 style: 코드 정리

* [feat] 포트폴리오 종목 조회 구현 (#49)

* #10 feat: 포트폴리오 종목 목록 조회 구현

* #10 feat: @JsonUnWraaped 적용

* [feat] ci/cd 파이프라인 개선 (#55)

* #51 fix: cicd 개선

- docker 추가

* #51 fix: cicd 테스트 브랜치 추가

* #10 feat: getFile -> getInputStream으로 변경

* #10 feat: 엘라스틱 서치 코드 제거 및 REST API 검색 구현

* #10 feat: 엘라스틱 서치 컨테이너 제거

* #10 chore: 엘라스틱 서치 의존성 제거

* #51 fix: 경로 변경

* [fix] 포스트맨 변경 사항 반영 (#56)

* #54 fix: postman 변경사항 반영

* #54 fix: postman 변경사항 반영

* [feat] 매입 이력 추가 서비스 구현 (#58)

* #19 feat: 매입 입력 추가 서비스 구현

* #19 test: 매입 입력 추가 서비스 테스트 코드 추가

* [feat] 매입 이력 수정 및 삭제 서비스 구현 (#61)

* #20 feat: 매입 입력 수정 서비스 구현 및 테스트 구현

* #20 docs: 샘플 데이터 추가

* #20 feat: 매입 이력 삭제 서비스 구현 및 테스트 코드 작성

* #20 feat: 포트폴리오 손익 내역 기록 서비스 구현

* #62 fix: 포트폴리오 목록 조회 응답에 securitiesFirm 프로퍼티 추가 (#63)

* #41 feat: 포트폴리오 수익 내역 서비스 구현

* [feat] 포트폴리오 손익 내역 기록 서비스 구현 (#65)

* #20 feat: 포트폴리오 손익 내역 기록 서비스 구현

* #41 feat: 포트폴리오 수익 내역 서비스 구현

* #41 fix: 포트폴리오 상세 조회시 securitiesFirm 프로퍼티 추가

* [feat] 포트폴리오 수익 내역 추가 서비스 구현 (#66)

* #20 feat: 포트폴리오 손익 내역 기록 서비스 구현

* #41 feat: 포트폴리오 수익 내역 서비스 구현

* #41 fix: 포트폴리오 상세 조회시 securitiesFirm 프로퍼티 추가

* #68 feat: 포트폴리오 상세 조회시 매입 내역 목록 조회할 수 있도록 구현

* [feat] 매입 내역 목록 조회 구현 (#69)

* #20 feat: 포트폴리오 손익 내역 기록 서비스 구현

* #41 feat: 포트폴리오 수익 내역 서비스 구현

* #41 fix: 포트폴리오 상세 조회시 securitiesFirm 프로퍼티 추가

* #68 feat: 포트폴리오 상세 조회시 매입 내역 목록 조회할 수 있도록 구현

* #68 feat: 포트폴리오 상세 조회시 알림에 대한 설정을 응답하도록 추가

* #68 feat: 포트폴리오 상세 조회시 총손익 공식 개선

* #68 feat: 주식 현재가 시세 클라이언트와 연결 구현

* [refactor] kis 서버 액세스 토큰 발급 만료 문제 해결 (#79)

* #75 feat: 실시간 포트폴리오 계산 데이터 응답 구현

* #75 refactor: accessToken 만료 개선

* [fix] 주식 현재가가 0인 경우 비동기적으로 수행되는 문제 해결 (#81)

* #75 feat: 실시간 포트폴리오 계산 데이터 응답 구현

* #75 refactor: accessToken 만료 개선

* #75 style: 불필요 코드 삭제

* #75 fix: 주식 현재가의 비동기적 실행 문제 해결

* #75 fix: 포트폴리오 목록 조회 문제 해결

* #75 fix: 병렬 스트림으로 변경

* #75 fix: 포트폴리오 상세 조회 API 개선

## 구현한 것

- 내용

## 기타

- 내용
